### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ readme = "./README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = "0"
+log = "0.4"
 unic-ucd-ident = { version = "0.9.0", default_features = false, features = ["id"] }
 
 [dev-dependencies]
-pretty_env_logger = "0"
+pretty_env_logger = "0.4"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.